### PR TITLE
Validado classe configurada no modelo, ao carregar referência.

### DIFF
--- a/ieducar/lib/CoreExt/Entity.php
+++ b/ieducar/lib/CoreExt/Entity.php
@@ -377,6 +377,9 @@ abstract class CoreExt_Entity implements CoreExt_Entity_Validatable
       }
       $return = $class[$value];
     }
+    else {
+      throw new Exception('A classe '. $class .' da referência ' . $key . ' é inválida.');
+    }
 
     return $return;
   }


### PR DESCRIPTION
* Atualmente o uso de classes inválidas nos modelos não está sendo
  validado o que pode ocorrer erros indesejados.